### PR TITLE
build: initial commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,102 @@
+// FIXME: generalize this pipeline some day for other 3rdparties
+
+pipeline {
+    agent {
+        label 'devenv'
+    }
+    parameters {
+        string(name: 'REPO', defaultValue: 'https://github.com/koenkk/zigbee2mqtt', description: 'repo to get zigbee2mqtt from')
+        string(name: 'BRANCH', defaultValue: 'master', description: 'for checkout step')
+        string(name: 'TAG', defaultValue: '', description: 'use with VERSION_TO_NAME to build custom version')
+        booleanParam(name: 'VERSION_TO_NAME', defaultValue: false, description: 'build package like zigbee2mqtt-1.18.1')
+        booleanParam(name: 'UPLOAD_TO_POOL', defaultValue: false, description: 'disabled by default for repo safety')
+        booleanParam(name: 'FORCE_OVERWRITE', defaultValue: false,
+                description: 'use only you know what you are doing, replace existing version of package')
+        booleanParam(name: 'ADD_VERSION_SUFFIX', defaultValue: true, description: 'for dev branches only')
+        string(name: 'WBDEV_IMAGE', defaultValue: 'contactless/devenv:latest',
+                description: 'docker image to use as devenv')
+        string(name: 'NPM_REGISTRY', defaultValue: '',
+                description: 'select alternative mirror if necessary, e.g. https://registry.npmjs.org/, http://r.cnpmjs.org/')
+    }
+    environment {
+        PROJECT_SUBDIR = 'zigbee2mqtt'
+        RESULT_SUBDIR = 'result'
+    }
+    stages {
+        stage('Cleanup workspace') { steps {
+            cleanWs deleteDirs: true, patterns: [[pattern: "$RESULT_SUBDIR", type: 'INCLUDE']]
+        }}
+        stage('Checkout') { steps { dir("$PROJECT_SUBDIR") {
+            git branch: params.BRANCH, url: params.REPO
+        }}}
+        stage('Checkout tag') {
+            when { expression {
+                (params.TAG != "")
+            }}
+            steps { dir("$PROJECT_SUBDIR") {
+                sshagent (credentials: ['jenkins-github-public-ssh']) {
+                    sh 'git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch --all'
+                    sh "git checkout ${params.TAG}"
+                }
+            }}
+        }
+        stage('Determine version suffix (this repo)') {
+            when { expression {
+                params.ADD_VERSION_SUFFIX && !wb.isBranchRelease(env.BRANCH_NAME)
+            }}
+            steps { script {
+                sshagent (credentials: ['jenkins-github-public-ssh']) {
+                    sh 'git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch --all'
+                }
+                env.WB_VERSION_SUFFIX = wb.makeVersionSuffixFromBranch()
+            }}
+        }
+        stage('Determine version') {
+            steps { dir("$PROJECT_SUBDIR") { script {
+                sshagent (credentials: ['jenkins-github-public-ssh']) {
+                    sh 'git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch --all'
+                }
+                env.PURE_VERSION = sh(returnStdout: true, script: "git describe --tags | sed -e 's/-.*//g'").trim()
+                env.VERSION = env.PURE_VERSION + env.WB_VERSION_SUFFIX
+                echo "Pure version: $PURE_VERSION"
+                echo "Version with suffix: $VERSION"
+            }}}
+        }
+        stage('Build') {
+            environment {
+                WBDEV_BUILD_METHOD="qemuchroot"
+                WBDEV_TARGET="stretch-armhf"
+            }
+            steps { script {
+                def name = params.VERSION_TO_NAME ? "zigbee2mqtt-${PURE_VERSION}" : "zigbee2mqtt";
+                def specialParams = "";
+                if (params.VERSION_TO_NAME) {
+                    specialParams = "--provides zigbee2mqtt --conflicts zigbee2mqtt --replaces zigbee2mqtt"
+                }
+
+                sh "printenv | sort"
+                sh "wbdev root printenv | sort"
+                sh "wbdev chroot bash -c 'NPM_REGISTRY=${params.NPM_REGISTRY} ./build.sh ${name} ${VERSION} ${PROJECT_SUBDIR} ${RESULT_SUBDIR} ${specialParams}'"
+            }}
+            post {
+                always {
+                    sh 'wbdev root chown -R jenkins:jenkins .'
+                }
+                success {
+                    archiveArtifacts artifacts: "$RESULT_SUBDIR/*.deb"
+                }
+            }
+        }
+        stage('Setup deploy') {
+            when { expression {
+                params.UPLOAD_TO_POOL
+            }}
+            steps { script {
+                wbDeploy projectSubdir: env.PROJECT_SUBDIR,
+                        forceOverwrite: params.FORCE_OVERWRITE,
+                        filesFilter: "$RESULT_SUBDIR/*.deb",
+                        withGithubRelease: false
+            }}
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@ zigbee2mqtt CI build for Wiren Board
 
 This repository contains scripts and extra files required to build
 zigbee2mqtt package for Wiren Board repository.
+
+How to build
+------------
+
+Using devenv (https://github.com/wirenboard/wirenboard):
+
+```console
+$ git clone https://github.com/Koenkk/zigbee2mqtt
+$ WBDEV_TARGET=wb6 WBDEV_BUILD_METHOD=qemuchroot wbdev chroot ./build.sh zigbee2mqtt <version> ./zigbee2mqtt ./result
+$ # .deb files are in result/ dir
+```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -xe
+
+NPM_REGISTRY=${NPM_REGISTRY:-}
+
+if [[ $# -lt 4 ]]; then
+    echo >&2 "Usage: $0 <pkg_name> <version> <z2m_dir> <result_dir> [optional fpm flags]"
+    echo >&2 "Env used:"
+    echo -e >&2 "\tNPM_REGISTRY\tnpm registry address override"
+    exit 2
+fi
+
+PKG_NAME=$1
+VERSION=$2
+PROJECT_SUBDIR=$3
+RESULT_SUBDIR=$4
+shift 4
+
+if [[ ! -d "$PROJECT_SUBDIR" ]]; then
+    echo "No project subdirectory $PROJECT_SUBDIR"
+    exit 2
+fi
+
+echo "Prepare environment"
+apt-get update
+apt-get install -y nodejs git make g++ gcc ruby ruby-dev rubygems build-essential
+gem install --no-document fpm -v 1.11.0
+                        
+if [[ -n "$NPM_REGISTRY" ]]; then
+    echo "Override NPM registry"
+    npm set registry "$NPM_REGISTRY"
+fi
+
+pushd "$PROJECT_SUBDIR" || exit 1
+npm ci -d
+npm run build -d || true  # required only for newer zigbee2mqtt to compile typescript
+popd || exit 1
+
+mkdir -p "$RESULT_SUBDIR"
+
+fpm -s dir -t deb -n "$PKG_NAME" \
+    --exclude 'mnt/data/root/zigbee2mqtt/.git*' \
+    --config-files mnt/data/root/zigbee2mqtt/data/configuration.yaml \
+    --deb-no-default-config-files \
+    --deb-systemd package/zigbee2mqtt.service \
+    --deb-recommends wb-zigbee2mqtt \
+    -m 'Wiren Board Robot <info@wirenboard.com>' \
+    --description 'Zigbee to MQTT bridge (package by Wiren Board team)' \
+    --url 'https://www.zigbee2mqtt.io/' \
+    --vendor 'Wiren Board' \
+    -d 'nodejs (>= 12.18.4)' \
+    --before-upgrade package/before-upgrade.sh \
+    --after-upgrade package/after-upgrade.sh \
+    -p "$RESULT_SUBDIR/${PKG_NAME}_${VERSION}_armhf.deb" \
+    -v "$VERSION" \
+    "$@" \
+    "$PROJECT_SUBDIR"=/mnt/data/root

--- a/package/after-upgrade.sh
+++ b/package/after-upgrade.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
+
+if [ -e "$CONFIG_FILE.wb-old" ]; then
+    echo "Restoring config file after upgrade from old malformed zigbee2mqtt package version"
+    mv $CONFIG_FILE.wb-old $CONFIG_FILE
+fi

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# In older zigbee2mqtt package builds data/configuration.yaml file
+# is not marked as conffile so it is not preserved during upgrade.
+# This script saves old configuration during upgrade from this
+# malformed version.
+
+CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
+
+if ! dpkg-query --showformat='\${Conffiles}' --show zigbee2mqtt | grep configuration.yaml >/dev/null; then
+    echo "Saving modified config file from old malformed zigbee2mqtt package"
+    mv $CONFIG_FILE $CONFIG_FILE.wb-old
+fi

--- a/package/configuration.yaml
+++ b/package/configuration.yaml
@@ -1,0 +1,10 @@
+homeassistant: false
+permit_join: false
+mqtt:
+  base_topic: zigbee2mqtt
+  server: 'mqtt://localhost'
+serial:
+  port: /dev/ttyMOD3
+advanced:
+  rtscts: false
+  last_seen: epoch

--- a/package/zigbee2mqtt.service
+++ b/package/zigbee2mqtt.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=zigbee2mqtt
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/npm start
+WorkingDirectory=/mnt/data/root/zigbee2mqtt
+StandardOutput=inherit
+StandardError=inherit
+Restart=always
+RestartSec=90
+StartLimitInterval=400
+StartLimitBurst=3
+User=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Переделал https://github.com/wirenboard/wirenboard/pull/98 на сборку из репозитория. Кажется, так будет аккуратней с точки зрения инфраструктуры.

Процедура сильно не поменялась, появилось больше отладочного вывода. Также добавил шаг `npm run build`, нужный для версии 1.25.0 (и, может, более старым), где используются модули с typescript.