### PR TITLE
Enable service auto-start

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         booleanParam(name: 'FORCE_OVERWRITE', defaultValue: false,
                 description: 'use only you know what you are doing, replace existing version of package')
         booleanParam(name: 'ADD_VERSION_SUFFIX', defaultValue: true, description: 'for dev branches only')
-        string(name: 'WB_REVISION', defaultValue: '', description: 'for rebuilds, like -wb101')
+        string(name: 'WB_REVISION', defaultValue: '-wb101', description: 'for rebuilds, like -wb101')
         string(name: 'WBDEV_IMAGE', defaultValue: 'contactless/devenv:latest',
                 description: 'docker image to use as devenv')
         string(name: 'NPM_REGISTRY', defaultValue: '',

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,8 @@ fpm -s dir -t deb -n "$PKG_NAME" \
     --config-files mnt/data/root/zigbee2mqtt/data/configuration.yaml \
     --deb-no-default-config-files \
     --deb-systemd package/zigbee2mqtt.service \
+    --deb-systemd-auto-start \
+    --deb-systemd-enable \
     --deb-recommends wb-zigbee2mqtt \
     -m 'Wiren Board Robot <info@wirenboard.com>' \
     --description 'Zigbee to MQTT bridge (package by Wiren Board team)' \


### PR DESCRIPTION
В [документации](https://wirenboard.com/wiki/Zigbee#%D0%A3%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BA%D0%B0_%D0%B8_%D0%BD%D0%B0%D1%81%D1%82%D1%80%D0%BE%D0%B9%D0%BA%D0%B0_zigbee2mqtt) заявлено:

> После установки пакета сервис zigbee2mqtt будет запускаться автоматически при старте контроллера