### PR TITLE
Fail build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,8 +51,16 @@ fi
 
 npm_build() {
     npm ci -d
+    if [[ $? -ne 0 ]]; then
+        echo "npm ci failed, exiting."
+        exit 1
+    fi
     if [[ "${PKG_NAME}" != "zigbee2mqtt-1.18.1" ]]; then
         npm run build -d  # required only for newer zigbee2mqtt to compile typescript
+        if [[ $? -ne 0 ]]; then
+            echo "npm run build failed, exiting."
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
Сейчас пайплайн успешно завершался даже при фейле npm ci.