### PR TITLE
add pnpm installation and update pnpm dependencies when upgrading z2m

### DIFF
--- a/package/after-upgrade.sh
+++ b/package/after-upgrade.sh
@@ -2,6 +2,9 @@
 
 CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 
+echo "Adding dependencies for pnpm"
+pnpm install --frozen-lockfile --prefix /mnt/data/root/zigbee2mqtt
+
 if [ -e "$CONFIG_FILE.wb-old" ]; then
     echo "Restoring config file after upgrade from old malformed zigbee2mqtt package version"
     mv $CONFIG_FILE.wb-old $CONFIG_FILE

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -11,3 +11,8 @@ if ! dpkg-query --showformat='\${Conffiles}' --show 'zigbee2mqtt*' | grep config
     echo "Saving modified config file from old malformed zigbee2mqtt package"
     mv $CONFIG_FILE $CONFIG_FILE.wb-old
 fi
+
+if ! command -v pnpm &> /dev/null; then
+    echo "pnpm is not installed. Install via corepack..."
+    corepack enable pnpm
+fi


### PR DESCRIPTION
Добавлено:
1. Установка pnpm перед обновление z2m , если не установлен.
2. Установка зависимостей pnpm после обновление z2m , если не установлен.

Проверено на:
1. WB6 wb-2401 при переходе с 1.35.3 на 2.1.1.
2. WB7 wb-2401 при переходе с 1.35.3 на 2.1.1.
3. WB8 wb-2410 при переходе с 1.42.0 на 2.1.1.
4. WB7 testimg при переходе с 1.42.0 на 2.1.1.
5. WB7 testimg при переходе с 1.42.0 на 2.1.1.