### PR TITLE
Fix build with ruby>=3.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         string(name: 'WB_REVISION', defaultValue: '-wb101', description: 'for rebuilds, like -wb101')
         string(name: 'WBDEV_IMAGE', defaultValue: 'contactless/devenv:latest',
                 description: 'docker image to use as devenv')
-        choice(name: 'WBDEV_TARGET', choices: ['bullseye-armhf', 'bullseye-arm64'], description: 'target architecture')
+        choice(name: 'WBDEV_TARGET', choices: ['bullseye-armhf', 'bullseye-arm64', 'trixie-armhf', 'trixie-arm64'], description: 'target architecture')
         choice(name: 'FPM_DEPENDS', choices: ['nodejs (>= 20)', 'nodejs-16'], description: 'zigbee2mqtt dependencies')
         string(name: 'NPM_REGISTRY', defaultValue: '',
                 description: 'select alternative mirror if necessary, e.g. https://registry.npmjs.org/, http://r.cnpmjs.org/')

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ echo "Prepare environment"
 apt-get update
 apt-get install -y git make g++ gcc ruby ruby-dev rubygems build-essential
 apt-get satisfy -y "$FPM_DEPENDS"
-gem install --no-document fpm -v 1.14.2
+gem install --no-document fpm -v 1.16.0
 
 corepack enable pnpm
 

--- a/package/zigbee2mqtt.service
+++ b/package/zigbee2mqtt.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/npm start
+SyslogIdentifier=zigbee2mqtt
 WorkingDirectory=/mnt/data/root/zigbee2mqtt
 StandardOutput=inherit
 StandardError=inherit


### PR DESCRIPTION
```sh
/var/lib/gems/3.3.0/gems/fpm-1.14.2/lib/fpm/package/dir.rb:46:in `input': undefined method `exists?' for class File (NoMethodError)

    if path =~ /.=./ && !File.exists?(chdir == '.' ? path : File.join(chdir, path))
                             ^^^^^^^^
```
Starting in ruby 3.2.0 the `exists?` alias for `exist?` has been removed. Debian 13 has ruby 3.3. Fixed in [fpm 1.15.1](https://github.com/jordansissel/fpm/releases/tag/v1.15.1).