### PR TITLE
add pnpm force option

### DIFF
--- a/package/after-upgrade.sh
+++ b/package/after-upgrade.sh
@@ -4,7 +4,7 @@ CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 
 echo "Adding dependencies for pnpm"
 # Dependencies already included in .deb — this just prevents runtime issues
-pnpm install --prod --frozen-lockfile --prefix /mnt/data/root/zigbee2mqtt
+pnpm install --prod --frozen-lockfile --force --prefix /mnt/data/root/zigbee2mqtt
 
 if [ -e "$CONFIG_FILE.wb-old" ]; then
     echo "Restoring config file after upgrade from old malformed zigbee2mqtt package version"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При смене релиза или переустановке пакета `pnpm install` задает вопрос о перестановке модулей, из за чего процесс прерывается в ожидании действия от пользователя.

___________________________________
**Что поменялось для пользователей:**
Теперь `pnpm install` вызывается с опцией `--force` и не прерывает процесс смены релиза.

___________________________________
**Как проверял/а:**
Собрал пакет на бидлдноде, установил его вручную, проверил, что `pnpm install` выполнятся без вопросов.

