### PR TITLE
jenkinsfile: fix makeVersionSuffixFromBranch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
                 sshagent (credentials: ['jenkins-github-public-ssh']) {
                     sh 'git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch --all'
                 }
-                env.WB_VERSION_SUFFIX = wb.makeVersionSuffixFromBranch()
+                env.WB_VERSION_SUFFIX = wb.makeVersionSuffixFromBranch(wb.getMainBranchName())
             }}
         }
         stage('Determine version') {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Фикс `java.lang.NoSuchMethodError: No such DSL method 'makeVersionSuffixFromBranch' found`, теперь бранч передается аргументом.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
дженкинс

