### PR TITLE
feat: wb-mqtt-zigbee ussage INT-926

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -114,7 +114,7 @@ fpm --input-type dir \
     --deb-systemd package/zigbee2mqtt.service \
     --deb-systemd-auto-start \
     --deb-systemd-enable \
-    --deb-recommends wb-zigbee2mqtt \
+    --deb-recommends wb-mqtt-zigbee \
     --maintainer 'Wiren Board Robot <info@wirenboard.com>' \
     --description 'Zigbee to MQTT bridge (package by Wiren Board team)' \
     --url 'https://www.zigbee2mqtt.io/' \

--- a/build.sh
+++ b/build.sh
@@ -118,7 +118,7 @@ fpm --input-type dir \
     --deb-systemd package/zigbee2mqtt.service \
     --deb-systemd-auto-start \
     --deb-systemd-enable \
-    --deb-recommends wb-mqtt-zigbee \
+	--deb-recommends 'wb-mqtt-zigbee | wb-zigbee2mqtt' \
     --maintainer 'Wiren Board Robot <info@wirenboard.com>' \
     --description 'Zigbee to MQTT bridge (package by Wiren Board team)' \
     --url 'https://www.zigbee2mqtt.io/' \

--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,8 @@ gem install --no-document fpm -v 1.16.0
 corepack enable pnpm
 # Workaround: corepack enable creates a broken shim in some environments
 # Always replace the shim with a wrapper to ensure it works correctly
-#printf '#!/bin/sh\nexec corepack pnpm "$@"\n' >/usr/bin/pnpm
-#chmod +x /usr/bin/pnpm
+printf '#!/bin/sh\nexec corepack pnpm "$@"\n' >/usr/bin/pnpm
+chmod +x /usr/bin/pnpm
 
 if [[ -n "$NPM_REGISTRY" ]]; then
     echo "Override NPM registry"

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,10 @@ apt-get satisfy -y "$FPM_DEPENDS"
 gem install --no-document fpm -v 1.16.0
 
 corepack enable pnpm
+# Workaround: corepack enable creates a broken shim in some environments
+# Always replace the shim with a wrapper to ensure it works correctly
+#printf '#!/bin/sh\nexec corepack pnpm "$@"\n' >/usr/bin/pnpm
+#chmod +x /usr/bin/pnpm
 
 if [[ -n "$NPM_REGISTRY" ]]; then
     echo "Override NPM registry"

--- a/package/after-upgrade.sh
+++ b/package/after-upgrade.sh
@@ -26,3 +26,15 @@ if ! grep -Pzq 'serial:\n(  .*\n)*  adapter: zstack' $CONFIG_FILE; then
   fi
   echo "zstack adapter type added to the configuration file"
 fi
+
+if ! grep -q '^availability:' "$CONFIG_FILE"; then
+  cat >> "$CONFIG_FILE" <<'EOF'
+availability:
+  enabled: true
+  active:
+    timeout: 10
+    max_jitter: 30000
+    backoff: true
+EOF
+  echo "availability section added to the configuration file"
+fi

--- a/package/configuration.yaml
+++ b/package/configuration.yaml
@@ -11,6 +11,12 @@ advanced:
   last_seen: epoch
   pan_id: GENERATE
   network_key: GENERATE
+availability:
+  enabled: true
+  active:
+    timeout: 10
+    max_jitter: 30000
+    backoff: true
 #frontend:
 #  port: 8081
 #  host: 0.0.0.0

--- a/package/zigbee2mqtt.service
+++ b/package/zigbee2mqtt.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=zigbee2mqtt
-After=network.target
+After=network.target mosquitto.service
+BindsTo=mosquitto.service
 
 [Service]
 ExecStart=/usr/bin/npm start


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Выпускаем новый конвертер [wb-mqtt-zigbee](https://github.com/wirenboard/wb-mqtt-zigbee)
___________________________________
**Что поменялось для пользователей:**

1. Изменяем предлагаемый пакет при установке на ```wb-mqtt-zigbee```

| Сценарий | Поведение |
| --- | --- |
| Новый пользователь ставит `zigbee2mqtt` | apt подтягивает `wb-mqtt-zigbee` как рекомендацию → новый конвертер |
| Старый пользователь обновляет `zigbee2mqtt` | `wb-zigbee2mqtt` уже установлен, `wb-mqtt-zigbee` имеет `deb-recommends: wb-mqtt-zigbee | wb-zigbee2mqtt` → apt **пропускает** рекомендацию, старый конвертер остаётся |
| Старый пользователь хочет перейти на новый | `apt remove wb-zigbee2mqtt && apt install wb-mqtt-zigbee` |

```Recommends``` — мягкая зависимость: apt ставит её автоматически, но не настаивает при конфликтах.

2. Добавляем  BindsTo mosquitto
z2m публикует `bridge/devices` как retained один раз при старте. z2m 2.x **не поддерживает** `bridge/request/devices` — запрос игнорируется (проверено экспериментально). Если mosquitto перезапускается без persistence (по умолчанию на WB), retained теряется. Без рестарта z2m сервис нового конвертера не получает список устройств → управление не работает.
`BindsTo=mosquitto.service` гарантирует, что z2m перезапустится вместе с mosquitto и переопубликует retained-топики.

3. Добавляем секцию ```availability```
`wb-mqtt-zigbee` подписывается на `zigbee2mqtt/{device}/availability` и отображает онлайн/офлайн статус устройств. Без этой секции z2m не публикует availability-топики.

___________________________________
**Как проверял/а:**


