### PR TITLE
feat: preserve user configuration on package upgrade INT-983

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,7 +113,6 @@ fpm --input-type dir \
     --version "$VERSION" \
     --exclude 'mnt/data/root/zigbee2mqtt/.git*' \
     --exclude 'mnt/data/root/zigbee2mqtt/.git/**' \
-    --config-files mnt/data/root/zigbee2mqtt/data/configuration.yaml \
     --deb-no-default-config-files \
     --deb-systemd package/zigbee2mqtt.service \
     --deb-systemd-auto-start \

--- a/build.sh
+++ b/build.sh
@@ -113,6 +113,7 @@ fpm --input-type dir \
     --version "$VERSION" \
     --exclude 'mnt/data/root/zigbee2mqtt/.git*' \
     --exclude 'mnt/data/root/zigbee2mqtt/.git/**' \
+    --config-files mnt/data/root/zigbee2mqtt/data/configuration.yaml \
     --deb-no-default-config-files \
     --deb-systemd package/zigbee2mqtt.service \
     --deb-systemd-auto-start \

--- a/package/after-upgrade.sh
+++ b/package/after-upgrade.sh
@@ -6,9 +6,16 @@ echo "Adding dependencies for pnpm"
 # Dependencies already included in .deb — this just prevents runtime issues
 pnpm install --prod --frozen-lockfile --force --prefix /mnt/data/root/zigbee2mqtt
 
+# Restore user configuration saved before upgrade
+if [ -e "$CONFIG_FILE.wb-upgrade-backup" ]; then
+    echo "Restoring configuration file after upgrade"
+    mv "$CONFIG_FILE.wb-upgrade-backup" "$CONFIG_FILE"
+fi
+
+# Legacy: restore config from old malformed package (without conffile mark)
 if [ -e "$CONFIG_FILE.wb-old" ]; then
     echo "Restoring config file after upgrade from old malformed zigbee2mqtt package version"
-    mv $CONFIG_FILE.wb-old $CONFIG_FILE
+    mv "$CONFIG_FILE.wb-old" "$CONFIG_FILE"
 fi
 
 if ! grep -Pzq 'serial:\n(  .*\n)*  adapter: zstack' $CONFIG_FILE; then

--- a/package/after-upgrade.sh
+++ b/package/after-upgrade.sh
@@ -2,15 +2,18 @@
 
 CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 
-echo "Adding dependencies for pnpm"
-# Dependencies already included in .deb — this just prevents runtime issues
-pnpm install --prod --frozen-lockfile --force --prefix /mnt/data/root/zigbee2mqtt
-
-# Restore user configuration saved before upgrade
+# Restore user configuration saved before upgrade.
+# Done first so that the config is safe even if a later step (pnpm install) fails;
+# successful mv also removes .wb-old, preventing a stale backup from leaking
+# into the next upgrade.
 if [ -e "$CONFIG_FILE.wb-old" ]; then
     echo "Restoring configuration file after upgrade"
     mv "$CONFIG_FILE.wb-old" "$CONFIG_FILE"
 fi
+
+echo "Adding dependencies for pnpm"
+# Dependencies already included in .deb — this just prevents runtime issues
+pnpm install --prod --frozen-lockfile --force --prefix /mnt/data/root/zigbee2mqtt
 
 if ! grep -Pzq 'serial:\n(  .*\n)*  adapter: zstack' $CONFIG_FILE; then
   LINE=$(awk '

--- a/package/after-upgrade.sh
+++ b/package/after-upgrade.sh
@@ -7,14 +7,8 @@ echo "Adding dependencies for pnpm"
 pnpm install --prod --frozen-lockfile --force --prefix /mnt/data/root/zigbee2mqtt
 
 # Restore user configuration saved before upgrade
-if [ -e "$CONFIG_FILE.wb-upgrade-backup" ]; then
-    echo "Restoring configuration file after upgrade"
-    mv "$CONFIG_FILE.wb-upgrade-backup" "$CONFIG_FILE"
-fi
-
-# Legacy: restore config from old malformed package (without conffile mark)
 if [ -e "$CONFIG_FILE.wb-old" ]; then
-    echo "Restoring config file after upgrade from old malformed zigbee2mqtt package version"
+    echo "Restoring configuration file after upgrade"
     mv "$CONFIG_FILE.wb-old" "$CONFIG_FILE"
 fi
 

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -15,7 +15,7 @@ if [ -e "$CONFIG_FILE" ]; then
     fi
 fi
 
-if ! command -v pnpm &> /dev/null; then
+if ! command -v pnpm >/dev/null 2>&1; then
     echo "pnpm is not installed. Install via corepack..."
     corepack enable pnpm
 fi

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -2,11 +2,11 @@
 
 CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 
-# configuration.yaml was previously marked as dpkg conffile, but on upgrade
-# dpkg prompts the user to replace or keep the modified config. Users often
-# press Y (replace) accidentally, which overwrites network_key, pan_id and
-# paired devices — effectively destroying the zigbee network.
-# So we removed the conffile mark and handle backup/restore ourselves.
+# configuration.yaml is marked as dpkg conffile, so on upgrade dpkg may
+# prompt the user to replace or keep the modified config. If the user
+# presses Y (replace), it would overwrite network_key, pan_id and paired
+# devices — effectively destroying the zigbee network.
+# As a safety net, we always backup the config and restore it after upgrade.
 if [ -e "$CONFIG_FILE" ]; then
     echo "Saving configuration file before upgrade"
     cp "$CONFIG_FILE" "$CONFIG_FILE.wb-old"

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -1,15 +1,12 @@
 #!/bin/sh
 
-# In older zigbee2mqtt package builds data/configuration.yaml file
-# is not marked as conffile so it is not preserved during upgrade.
-# This script saves old configuration during upgrade from this
-# malformed version.
-
 CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 
-if ! dpkg-query --showformat='\${Conffiles}' --show 'zigbee2mqtt*' | grep configuration.yaml >/dev/null; then
-    echo "Saving modified config file from old malformed zigbee2mqtt package"
-    mv $CONFIG_FILE $CONFIG_FILE.wb-old
+# Always backup configuration before upgrade to preserve user settings
+# (network_key, pan_id, devices, etc.)
+if [ -e "$CONFIG_FILE" ]; then
+    echo "Saving configuration file before upgrade"
+    cp "$CONFIG_FILE" "$CONFIG_FILE.wb-upgrade-backup"
 fi
 
 if ! command -v pnpm &> /dev/null; then

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -9,7 +9,10 @@ CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 # As a safety net, we always backup the config and restore it after upgrade.
 if [ -e "$CONFIG_FILE" ]; then
     echo "Saving configuration file before upgrade"
-    cp "$CONFIG_FILE" "$CONFIG_FILE.wb-old"
+    if ! cp "$CONFIG_FILE" "$CONFIG_FILE.wb-old"; then
+        echo "Failed to back up $CONFIG_FILE — aborting upgrade" >&2
+        exit 1
+    fi
 fi
 
 if ! command -v pnpm &> /dev/null; then

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -6,7 +6,7 @@ CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 # (network_key, pan_id, devices, etc.)
 if [ -e "$CONFIG_FILE" ]; then
     echo "Saving configuration file before upgrade"
-    cp "$CONFIG_FILE" "$CONFIG_FILE.wb-upgrade-backup"
+    cp "$CONFIG_FILE" "$CONFIG_FILE.wb-old"
 fi
 
 if ! command -v pnpm &> /dev/null; then

--- a/package/before-upgrade.sh
+++ b/package/before-upgrade.sh
@@ -2,8 +2,11 @@
 
 CONFIG_FILE=/mnt/data/root/zigbee2mqtt/data/configuration.yaml
 
-# Always backup configuration before upgrade to preserve user settings
-# (network_key, pan_id, devices, etc.)
+# configuration.yaml was previously marked as dpkg conffile, but on upgrade
+# dpkg prompts the user to replace or keep the modified config. Users often
+# press Y (replace) accidentally, which overwrites network_key, pan_id and
+# paired devices — effectively destroying the zigbee network.
+# So we removed the conffile mark and handle backup/restore ourselves.
 if [ -e "$CONFIG_FILE" ]; then
     echo "Saving configuration file before upgrade"
     cp "$CONFIG_FILE" "$CONFIG_FILE.wb-old"


### PR DESCRIPTION

___________________________________
**Что происходит; кому и зачем нужно:**
При обновлении ```dpkg``` показывал промпт с предложением заменить изменённый конфиг, если в новой версии поменялся конфиг по умолчанию. Если  пользователь выбирал ```"Y"```, конфиг перезаписывался   (```pan_id: GENERATE, network_key: GENERATE```), ```zigbee2mqtt``` создавал новую сеть и все спаренные устройства терялись. Происходило из-за того, что не создавался бэкап пользовательского конфига.
___________________________________
**Что поменялось для пользователей:**
Копия пользовательского конфига делается всегда, а потом восстанавливается скриптом установки ```package/after-upgrade.sh```

___________________________________
**Как проверял/а:**

  - Проверено на контроллере WB
